### PR TITLE
Set content type of feed entries

### DIFF
--- a/yrss.py
+++ b/yrss.py
@@ -92,13 +92,13 @@ def generatefeed(user):
         item.updated(dateutil.parser.parse(published))
         item.id(video_id)
         item.content('''
-<a href="{url}"><img src="{img}" /></a>
+<a href="{url}"><img src="{img}" /></a><br />
 <a href="{url}">{title}</a>
 '''.format(
             url = video_url,
             img = thumbnail,
             title = title,
-        ))
+        ), None, 'html')
 
     # Cache to disk
     feed_txt = feed.atom_str()


### PR DESCRIPTION
feedgen escapes content normally and so the output is something like this:

```
<content>
&lt;a href="[...]"&gt;&lt;img src="[...]" /&gt;&lt;/a&gt;
&lt;a href="[...]"&gt;[...]&lt;/a&gt;
</content>
```

Some readers will parse this as raw text and therefore the the feed looks broken.

To fix this set the type of the content so all readers know how to interpret it.

```
<content type="html">
<a href="[...]"><img src="[...]" /></a>
<a href="[...]">[...]</a>
</content>
```
