### PR TITLE
Updates Readme to reflect the new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,11 @@ Google recently discontinued YouTube RSS feeds for individual user uploads. This
 
 To run it, specify your YouTube API key as `API_KEY` in your environment.
 
-Feeds can be found at `/{username}.xml` and will be cached for `CACHE_TIME` (default is one hour).
+Feeds can be found at:
+
+* `/user/{username}.xml`
+* `/user/{username}/atom.xml`
+* `/channel/{channelid}.xml`
+* `/channel/{channelid}/atom.xml`
+
+Feeds will be cached for `CACHE_TIME` (default is one hour).


### PR DESCRIPTION
Btw.:

Seems like youtube brought back official feeds:

```
https://www.youtube.com/feeds/videos.xml?channel_id=CHANNELID
https://www.youtube.com/feeds/videos.xml?user=USERNAME
https://www.youtube.com/feeds/videos.xml?playlist_id=PLAYLISTID
```

Source: https://www.reddit.com/r/youtube/comments/339idg/youtube_just_dropped_its_support_for_rssatom_feeds/

**Update**
- Added Playlist-Feed url
